### PR TITLE
Update terminal keybindings: clear kitty defaults, add zellij shortcuts

### DIFF
--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -34,24 +34,26 @@ placement_strategy center
 term xterm-kitty
 
 # Key binds
-map cmd+1 goto_tab 1
-map cmd+2 goto_tab 2
-map cmd+3 goto_tab 3
-map cmd+4 goto_tab 4
-map cmd+5 goto_tab 5
-map cmd+6 goto_tab 6
-map cmd+7 goto_tab 7
-map cmd+8 goto_tab 8
-map cmd+9 goto_tab 9
-map ctrl+1 goto_tab 1
-map ctrl+2 goto_tab 2
-map ctrl+3 goto_tab 3
-map ctrl+4 goto_tab 4
-map ctrl+5 goto_tab 5
-map ctrl+6 goto_tab 6
-map ctrl+7 goto_tab 7
-map ctrl+8 goto_tab 8
-map ctrl+9 goto_tab 9
+clear_all_shortcuts yes
+
+# map cmd+1 goto_tab 1
+# map cmd+2 goto_tab 2
+# map cmd+3 goto_tab 3
+# map cmd+4 goto_tab 4
+# map cmd+5 goto_tab 5
+# map cmd+6 goto_tab 6
+# map cmd+7 goto_tab 7
+# map cmd+8 goto_tab 8
+# map cmd+9 goto_tab 9
+# map ctrl+1 goto_tab 1
+# map ctrl+2 goto_tab 2
+# map ctrl+3 goto_tab 3
+# map ctrl+4 goto_tab 4
+# map ctrl+5 goto_tab 5
+# map ctrl+6 goto_tab 6
+# map ctrl+7 goto_tab 7
+# map ctrl+8 goto_tab 8
+# map ctrl+9 goto_tab 9
 
 map cmd+c copy_to_clipboard
 map cmd+v paste_from_clipboard

--- a/config/zellij/config.kdl
+++ b/config/zellij/config.kdl
@@ -14,7 +14,7 @@ keybinds clear-defaults=true {
         bind "f" { ToggleFloatingPanes; SwitchToMode "normal"; }
     }
     tab {
-        bind "Shift Super t" { SwitchToMode "normal"; }
+        bind "Super t" { SwitchToMode "normal"; }
         bind "left" { GoToPreviousTab; }
         bind "down" { GoToNextTab; }
         bind "up" { GoToPreviousTab; }
@@ -37,7 +37,6 @@ keybinds clear-defaults=true {
         bind "tab" { ToggleTab; }
     }
     resize {
-        bind "Shift Super n" { SwitchToMode "normal"; }
         bind "Super r" { SwitchToMode "normal"; }
         bind "left" { Resize "Increase left"; }
         bind "down" { Resize "Increase down"; }
@@ -143,14 +142,12 @@ keybinds clear-defaults=true {
         bind "Shift Super h" { SwitchToMode "scroll"; }
     }
     shared_except "locked" "tab" "entersearch" "renametab" "renamepane" "prompt" "tmux" {
-        bind "Shift Super t" { SwitchToMode "tab"; }
         bind "Super t" { SwitchToMode "tab"; }
     }
     shared_except "locked" "pane" "entersearch" "renametab" "renamepane" "prompt" "tmux" {
         bind "Shift Super p" { SwitchToMode "pane"; }
     }
     shared_except "locked" "resize" "entersearch" "renametab" "renamepane" "prompt" "tmux" {
-        bind "Shift Super n" { SwitchToMode "resize"; }
         bind "Super r" { SwitchToMode "resize"; }
     }
     shared_except "normal" "locked" "entersearch" {

--- a/config/zellij/config.kdl
+++ b/config/zellij/config.kdl
@@ -38,10 +38,6 @@ keybinds clear-defaults=true {
     }
     resize {
         bind "Super r" { SwitchToMode "normal"; }
-        bind "left" { Resize "Increase left"; }
-        bind "down" { Resize "Increase down"; }
-        bind "up" { Resize "Increase up"; }
-        bind "right" { Resize "Increase right"; }
         bind "w" { Resize "Increase right"; }
         bind "n" { Resize "Decrease right"; }
         bind "t" { Resize "Increase down"; }

--- a/config/zellij/config.kdl
+++ b/config/zellij/config.kdl
@@ -38,10 +38,15 @@ keybinds clear-defaults=true {
     }
     resize {
         bind "Shift Super n" { SwitchToMode "normal"; }
+        bind "Super r" { SwitchToMode "normal"; }
         bind "left" { Resize "Increase left"; }
         bind "down" { Resize "Increase down"; }
         bind "up" { Resize "Increase up"; }
         bind "right" { Resize "Increase right"; }
+        bind "w" { Resize "Increase right"; }
+        bind "n" { Resize "Decrease right"; }
+        bind "t" { Resize "Increase down"; }
+        bind "s" { Resize "Decrease down"; }
     }
     move {
         bind "Shift Super m" { SwitchToMode "normal"; }
@@ -94,6 +99,26 @@ keybinds clear-defaults=true {
             SwitchToMode "normal"
         }
     }
+    normal {
+        bind "Super 1" { GoToTab 1; }
+        bind "Super 2" { GoToTab 2; }
+        bind "Super 3" { GoToTab 3; }
+        bind "Super 4" { GoToTab 4; }
+        bind "Super 5" { GoToTab 5; }
+        bind "Super 6" { GoToTab 6; }
+        bind "Super 7" { GoToTab 7; }
+        bind "Super 8" { GoToTab 8; }
+        bind "Super 9" { GoToTab 9; }
+        bind "Ctrl 1" { GoToTab 1; }
+        bind "Ctrl 2" { GoToTab 2; }
+        bind "Ctrl 3" { GoToTab 3; }
+        bind "Ctrl 4" { GoToTab 4; }
+        bind "Ctrl 5" { GoToTab 5; }
+        bind "Ctrl 6" { GoToTab 6; }
+        bind "Ctrl 7" { GoToTab 7; }
+        bind "Ctrl 8" { GoToTab 8; }
+        bind "Ctrl 9" { GoToTab 9; }
+    }
     shared {
         bind "Shift left" { MoveFocus "left"; }
         bind "Shift right" { MoveFocus "right"; }
@@ -119,12 +144,14 @@ keybinds clear-defaults=true {
     }
     shared_except "locked" "tab" "entersearch" "renametab" "renamepane" "prompt" "tmux" {
         bind "Shift Super t" { SwitchToMode "tab"; }
+        bind "Super t" { SwitchToMode "tab"; }
     }
     shared_except "locked" "pane" "entersearch" "renametab" "renamepane" "prompt" "tmux" {
         bind "Shift Super p" { SwitchToMode "pane"; }
     }
     shared_except "locked" "resize" "entersearch" "renametab" "renamepane" "prompt" "tmux" {
         bind "Shift Super n" { SwitchToMode "resize"; }
+        bind "Super r" { SwitchToMode "resize"; }
     }
     shared_except "normal" "locked" "entersearch" {
         bind "enter" { SwitchToMode "normal"; }


### PR DESCRIPTION
- kitty: add clear_all_shortcuts, comment out tab-switching bindings (cmd/ctrl 1-9), keeping only cmd+c/v
- zellij: bind Super+r to enter resize mode, w/n/t/s for wider/narrower/taller/shorter
- zellij: bind Super/Ctrl 1-9 in normal mode for direct tab switching
- zellij: bind Super+t to enter tab mode

https://claude.ai/code/session_01NUCBwAaRruG3fBq3f3gWMS