### PR TITLE
Maintain cwd in smart_split for remote zmx panes

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -12,10 +12,6 @@ Context: Kitty supports modal keybinds just like zellij, which the current keybi
  (maybe best to implement a kitten that wraps the existing tab_bar and floats the information on the right side of the bar).
 Ask: Modal bindings are setup and there's feedback in the tab bar on which mode is active, on the right side.
 
-# kitty smart_split cwd on the remote and/or local
-Context: smart_split does not maintain the cwd when launching a split. Ideally this will maintain the cwd when working locally or in a ZMX session over ssh. The shift-split override should remain without cwd.
-Ask: Opening a "smart_split" maintains the cwd in the new pane regardless of local or remote connection.
-
 # zmx.zsh wrapper cli?
 Context: There's a number of small helpers now (zp, zmx-pick, zx, zk, zka, etc) which makes it less than ideal for memorizing them all. Especially since zp, zx, and zmx-pick overlap. Ideally we create a small utility to wrap all this functionality into a CLI, so it's easier to discover and interact with the commands.
 Ask: A single entrypoint to all these commands, with tab completion support.

--- a/config/kitty/kittens/smart_split.py
+++ b/config/kitty/kittens/smart_split.py
@@ -2,13 +2,16 @@
 smart_split.py — context-aware pane split.
 
 If the focused window has a zmx_session user var (set by zp when opening a
-remote session), opens a new zmx pane via `zp`. Otherwise opens a plain local
+remote session), opens a new zmx pane via `zp --from <session>` so the new
+session starts in the origin session's cwd. Otherwise opens a plain local
 split — identical to the old launch --cwd=current behaviour, with no overhead.
 
 Usage in kitty.conf:
     map cmd+shift+p>h kitten kittens/smart_split.py hsplit
     map cmd+shift+p>v kitten kittens/smart_split.py vsplit
 """
+
+import shlex
 
 from kittens.tui.handler import result_handler
 
@@ -24,6 +27,7 @@ def handle_result(args, answer, target_window_id, boss):
     zmx_session = (w.user_vars.get('zmx_session', '') if w else '')
 
     if zmx_session:
-        boss.call_remote_control(w, ('launch', f'--location={location}', 'zsh', '-ic', 'zp'))
+        cmd = f'zp --from {shlex.quote(zmx_session)}'
+        boss.call_remote_control(w, ('launch', f'--location={location}', 'zsh', '-ic', cmd))
     else:
         boss.call_remote_control(w, ('launch', f'--location={location}', '--cwd=current'))

--- a/config/zsh/zmx.zsh
+++ b/config/zsh/zmx.zsh
@@ -84,6 +84,27 @@ zmx-pick() {
   zmx-attach "$session_name"
 }
 
+# zmx-split-from <origin-session> <new-session> — attach a new session that
+# starts in the origin session's current working directory. The pid reported by
+# `zmx list` is the session's shell process, so /proc/<pid>/cwd tracks its live
+# cwd; fall back to the recorded start_dir (non-Linux hosts, dead pid), then
+# $HOME. Used by smart_split.py via `zp --from` so remote splits keep the cwd.
+zmx-split-from() {
+  local origin="${1:?zmx-split-from: origin session required}"
+  local session="${2:?zmx-split-from: new session name required}"
+  local line pid start_dir dir
+  line=$(zmx list 2>/dev/null | grep -F "name=${origin}"$'\t')
+  pid=${line#*pid=}
+  pid=${pid%%$'\t'*}
+  start_dir=${line#*start_dir=}
+  start_dir=${start_dir%%$'\t'*}
+  dir=$(readlink "/proc/${pid}/cwd" 2>/dev/null)
+  [[ -d "$dir" ]] || dir="$start_dir"
+  [[ -d "$dir" ]] || dir="$HOME"
+  cd "$dir" || cd "$HOME"
+  zmx-attach "$session"
+}
+
 # zk — kill the current zmx session (requires $ZMX_SESSION to be set by zmx)
 zk() {
   if [[ -z "${ZMX_SESSION:-}" ]]; then
@@ -124,10 +145,12 @@ if ! typeset -f _zmx_host >/dev/null 2>&1; then
   }
 fi
 
-# zp [name] — open a pane attached to a named zmx session on the remote host.
-# If no name is given, auto-generates one (p<HHMMSS>). The session is created
-# if it doesn't exist, or reattached if it does. When the SSH connection ends,
-# the local shell remains open.
+# zp [--from <session>] [name] — open a pane attached to a named zmx session on
+# the remote host. If no name is given, auto-generates one (p<HHMMSS>). The
+# session is created if it doesn't exist, or reattached if it does. When the
+# SSH connection ends, the local shell remains open.
+# --from <session> starts the new session in <session>'s current working
+# directory (via zmx-split-from on the remote) — used by smart_split.py.
 # Routes through zmx-attach (sourced on the remote) so the kitty window gets
 # tagged with the session name — covers zp, zx and manual ssh uniformly.
 zp() {
@@ -135,11 +158,21 @@ zp() {
     zx
     return
   }
-  local host session
+  local host session origin remote_cmd
+  if [[ "${1:-}" == "--from" ]]; then
+    origin="${2:?zp: --from requires a session name}"
+    shift 2
+  fi
   host="$(_zmx_host)" || return 1
   session="${1:-p$(date +%H%M%S)}"
+  if [[ -n "${origin:-}" ]]; then
+    # (qqq) double-quotes the names — safe inside the single-quoted zsh -c below
+    remote_cmd="zmx-split-from ${(qqq)origin} ${(qqq)session}"
+  else
+    remote_cmd="zmx-attach ${session}"
+  fi
   command ssh -t \
-    -o "RemoteCommand=zsh -c 'source ~/.config/zsh/zmx.zsh; zmx-attach ${session}'" \
+    -o "RemoteCommand=zsh -c 'source ~/.config/zsh/zmx.zsh; ${remote_cmd}'" \
     "${host}"
 }
 


### PR DESCRIPTION
Closes the TODOS entry on smart_split cwd handling.

## What

- **`config/zsh/zmx.zsh`**: new `zmx-split-from <origin> <new>` helper — resolves the origin zmx session's live cwd on the remote via `/proc/<pid>/cwd` (the pid from `zmx list` is the session's shell), falling back to the recorded `start_dir`, then `$HOME`, before attaching the new session (which inherits the cwd). `zp` gains a `--from <session>` flag that routes its RemoteCommand through this helper; plain `zp`, `zx`, and `--pick` are unchanged.
- **`config/kitty/kittens/smart_split.py`**: the zmx branch now launches `zp --from <session>` (shell-escaped via `shlex.quote`) instead of a bare `zp`, so remote splits open in the origin pane's directory. The local branch keeps `--cwd=current`.
- The shift-split overrides in `keys.conf` are untouched and remain cwd-less, per the TODO.
- Removed the completed TODOS.md entry.

## Testing

- Created a real zmx session, `cd`'d it to `/var/log` via `zmx send`, and confirmed `zmx-split-from` (with `zmx-attach` stubbed) attaches from `/var/log`; a missing origin session falls back to `$HOME`.
- Confirmed `zp --from` builds `RemoteCommand=zsh -c 'source ~/.config/zsh/zmx.zsh; zmx-split-from "scwd" "p083339"'`, with correct quoting for session names containing spaces.
- `zsh -n` syntax check, `shfmt` formatting, and `py_compile` on the kitten all pass.
- Not yet exercised: the full mac → ssh → remote keybind round trip (needs the updated zmx.zsh deployed on the remote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)